### PR TITLE
Make the notification behavior consistent with official MIUI

### DIFF
--- a/push/src/main/java/com/xiaomi/xmsf/push/notification/NotificationController.java
+++ b/push/src/main/java/com/xiaomi/xmsf/push/notification/NotificationController.java
@@ -159,6 +159,11 @@ public class NotificationController {
     public static void publish(Context context, int id, String packageName, Notification.Builder localBuilder) {
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 
+        // Make the behavior consistent with official MIUI
+        Bundle extras = new Bundle();
+        extras.putString("target_package", packageName);
+        localBuilder.addExtras(extras);
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             //Forward Compatibility
             registerChannelIfNeeded(context, packageName);


### PR DESCRIPTION
There is a "target_package" string field in the extras of official MIUI notification.
Some other notification helper apps can use that to identify the target app of the notification.